### PR TITLE
add details endpoint; support passthrough to ubuntu store

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+ENV = env
+
+snap: ## Snap it up
+	snapcraft clean snapstore
+	snapcraft snap
+
+$(ENV):
+	virtualenv $(ENV)
+
+deps: env ## install dependencies
+	$(ENV)/bin/pip install -q -r requirements.txt
+
+lint: env ## flake8 the source
+	$(ENV)/bin/flake8 store.py --max-line-length=99
+
+clean: ## tidy up the house
+	rm snapstore-example*.snap
+	snapcraft clean
+	rm -r $(ENV)
+
+run: env deps
+	$(ENV)/bin/python store.py
+
+help:
+	@grep -P '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
+
+.PHONY: all deps lint clean snap help

--- a/README.md
+++ b/README.md
@@ -55,11 +55,6 @@ E.g. on Ubuntu 16.04:
 sudo apt install snapd
 ```
 
-Ensure core snap gets installed from the normal store, triggered on first snap install.
-```
-sudo snap install hello
-```
-
 Edit /etc/environment, add your store URL, e.g.:
 ```
 SNAPPY_FORCE_CPI_URL=http://localhost:5000/api/v1/
@@ -90,11 +85,14 @@ $ snap install bar
 
 Name  Version  Rev  Developer  Notes
 bar   2.5      1    testuser   -
+
+$ snap refresh bar
+
+Name  Version  Rev  Developer  Notes
+bar   2.5      2    testuser   -
 ```
 
 # Known issues
 
 - It's just an example, probably lots!
 - snap refresh (bulk) not supported
-- issue above w/having to install core from canonical store.
-- newer details endpoint not implemented (will be needed in >2.0.9)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 Flask==0.11.1
+requests==2.10.0
+flake8==2.6.2

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: snapstore-example
-version: 0.1
+version: 0.3
 confinement: strict
 summary: Minimalist example snap store
 description: |


### PR DESCRIPTION
add details endpoint; support passthrough to ubuntu store for unknown snaps, allowing the core snap to be pulled on first snap install.
